### PR TITLE
WIP: creating new Idea object not adding timestamps

### DIFF
--- a/spec/controllers/api/v1/ideas_controller_spec.rb
+++ b/spec/controllers/api/v1/ideas_controller_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 describe Api::V1::IdeasController, type: :controller do
 
-  let!(:idea1) { create(:idea) }
-  let!(:idea2) { create(:idea) }
+  let!(:idea1) { Idea.create(title: "Awesome Idea", body: "Awesome Description") }
+  let!(:idea2) { Idea.create(title: "Awesome Idea 2", body: "Awesome Description 2") }
 
   describe "GET #index" do
     it "returns http success" do
+      binding.pry
       get :index, format: :json
       expect(response).to have_http_status(:success)
     end
@@ -32,9 +33,27 @@ describe Api::V1::IdeasController, type: :controller do
       assert_equal idea2.title, object2["title"]
       assert_equal idea2.body, object2["body"]
       assert_equal idea2.quality, object2["quality"]
+    end
+  end
 
+  describe "POST #create" do
+    it "returns http success" do
+      get :create, format: :json, title: 'New Title', body: 'New Body'
+      expect(response).to have_http_status(:success)
     end
 
+    it "returns one object" do
+      get :create, format: :json, title: 'New Title', body: 'New Body'
+      assert_kind_of Hash, json_response
+    end
+
+    it "returns the correct object" do
+      get :create, format: :json, title: 'New Title', body: 'New Body'
+
+      assert_equal idea1.title, json_response["title"]
+      assert_equal idea1.body, json_response["body"]
+      assert_equal idea1.quality, json_response["quality"]
+    end
   end
 
 end

--- a/spec/controllers/ideas_controller_spec.rb
+++ b/spec/controllers/ideas_controller_spec.rb
@@ -2,4 +2,11 @@ require 'rails_helper'
 
 RSpec.describe IdeasController, type: :controller do
 
+  describe "GET #index" do
+    it "returns http success" do
+      get :index, format: :json
+      expect(response).to have_http_status(:success)
+    end
+
+  end
 end


### PR DESCRIPTION
@stevekinney, @rrgayhart or @tessgriffin

I'm having trouble setting up any controller tests, because for some reason any object created in rspec is missing timestamps.
(I need the timestamp for chronological order)
I've tried Idea.create and Factory Girl, and in both situations the timestamps are missing.

I don't know if this means anything, but when I did rails g migration, timestamps weren't automatically added to that either, I had to put them into the migration file by hand.

Have you ever seen anything like that before? I've googled the heck out of it and can't find anything.
Thanks!
